### PR TITLE
Fix inferred dir overwrite

### DIFF
--- a/fsOp/placefile.go
+++ b/fsOp/placefile.go
@@ -101,16 +101,13 @@ func PlaceFile(afs fs.FS, fmeta fs.Metadata, body io.Reader, skipChown bool) err
 			}
 		}
 	case fs.Type_Dir:
-		if fmeta.Name == (fs.RelPath{}) {
-			// for the base dir only:
-			// the dir may exist; we'll just chown+chmod+chtime it.
-			// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.
-			if existingFmeta, err := afs.LStat(fmeta.Name); err == nil && existingFmeta.Type == fs.Type_Dir {
-				if err := afs.Chmod(fmeta.Name, fmeta.Perms); err != nil {
-					return err
-				}
-				break
+		// the dir may exist; we'll just chown+chmod+chtime it.
+		// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.
+		if existingFmeta, err := afs.LStat(fmeta.Name); err == nil && existingFmeta.Type == fs.Type_Dir {
+			if err := afs.Chmod(fmeta.Name, fmeta.Perms); err != nil {
+				return err
 			}
+			break
 		}
 		if err := afs.Mkdir(fmeta.Name, fmeta.Perms); err != nil {
 			return err

--- a/transmat/mixins/fshash/bucket_memory.go
+++ b/transmat/mixins/fshash/bucket_memory.go
@@ -24,6 +24,32 @@ func (b *MemoryBucket) AddRecord(metadata fs.Metadata, contentHash []byte) {
 	b.lines = append(b.lines, Record{name, metadata, contentHash})
 }
 
+func (b *MemoryBucket) HasRecord(metadata fs.Metadata) bool {
+	name := metadata.Name.String()
+	if metadata.Type == fs.Type_Dir {
+		name += "/"
+	}
+	for _, l := range b.lines {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *MemoryBucket) UpdateRecord(metadata fs.Metadata, contentHash []byte) {
+	name := metadata.Name.String()
+	if metadata.Type == fs.Type_Dir {
+		name += "/"
+	}
+	for n, l := range b.lines {
+		if l.Name == name {
+			b.lines[n].Metadata = metadata
+			b.lines[n].ContentHash = contentHash
+		}
+	}
+}
+
 /*
 	Get a `treewalk.Node` that starts at the root of the bucket.
 	The walk will be in deterministic, sorted order (and thus is appropriate


### PR DESCRIPTION
If a tar file contains an implicit directory before an explicitly defined directory, rio will create the implicit directory then error when attempting to create the explicit one. To deal with this, we need to update directories instead of adding them with an implicit directory already exists.

This PR implements a sorted map for the MemoryBucket type to allow for efficient updates. It also modifies the strategy for tar unpacking to update duplicated dirs when needed. Finally, we allow all dirs (not just the root) to be updated, which will modify attrs.