### PR TITLE
Fix inferred dir overwrite

### DIFF
--- a/fsOp/placefile.go
+++ b/fsOp/placefile.go
@@ -101,16 +101,13 @@ func PlaceFile(afs fs.FS, fmeta fs.Metadata, body io.Reader, skipChown bool) err
 			}
 		}
 	case fs.Type_Dir:
-		if fmeta.Name == (fs.RelPath{}) {
-			// for the base dir only:
-			// the dir may exist; we'll just chown+chmod+chtime it.
-			// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.
-			if existingFmeta, err := afs.LStat(fmeta.Name); err == nil && existingFmeta.Type == fs.Type_Dir {
-				if err := afs.Chmod(fmeta.Name, fmeta.Perms); err != nil {
-					return err
-				}
-				break
+		// the dir may exist; we'll just chown+chmod+chtime it.
+		// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.
+		if existingFmeta, err := afs.LStat(fmeta.Name); err == nil && existingFmeta.Type == fs.Type_Dir {
+			if err := afs.Chmod(fmeta.Name, fmeta.Perms); err != nil {
+				return err
 			}
+			break
 		}
 		if err := afs.Mkdir(fmeta.Name, fmeta.Perms); err != nil {
 			return err

--- a/fsOp/placefile.go
+++ b/fsOp/placefile.go
@@ -39,6 +39,11 @@ var (
 	This may be considered a security concern; you should whitelist inputs
 	if using this to provision a sandbox.
 
+	When the metadata describes a directory, and the existing data on the filesystem
+	is also a directory, the attributes will be assigned without comment. For all
+	other types (files, symlinks, device nodes, etc), using PlaceFile will error
+	if there is existing data.
+
 	If skipChown is true, it does what it says on the tin: skips setting ownership.
 	This will result in UIDs and GIDs from the rio process being in effect;
 	it's also a rough proxy for "don't require priviledged operations".

--- a/transmat/mixins/fshash/bucket.go
+++ b/transmat/mixins/fshash/bucket.go
@@ -43,13 +43,6 @@ func (e ErrInvalidFilesystem) Error() string {
 	return fmt.Sprintf("invariant broken while traversing fshash bucket: %s", e.Msg)
 }
 
-// for sorting
-type recordsByFilename []Record
-
-func (a recordsByFilename) Len() int           { return len(a) }
-func (a recordsByFilename) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a recordsByFilename) Less(i, j int) bool { return a[i].Name < a[j].Name }
-
 /*
 	RecordIterator is used for walking Bucket contents in hash-ready order.
 

--- a/transmat/mixins/fshash/bucket_memory.go
+++ b/transmat/mixins/fshash/bucket_memory.go
@@ -24,6 +24,32 @@ func (b *MemoryBucket) AddRecord(metadata fs.Metadata, contentHash []byte) {
 	b.lines = append(b.lines, Record{name, metadata, contentHash})
 }
 
+func (b *MemoryBucket) HasRecord(metadata fs.Metadata) bool {
+	name := metadata.Name.String()
+	if metadata.Type == fs.Type_Dir {
+		name += "/"
+	}
+	for _, l := range b.lines {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *MemoryBucket) UpdateRecord(metadata fs.Metadata, contentHash []byte) {
+	name := metadata.Name.String()
+	if metadata.Type == fs.Type_Dir {
+		name += "/"
+	}
+	for n, l := range b.lines {
+		if l.Name == name {
+			b.lines[n].Metadata = metadata
+			b.lines[n].ContentHash = contentHash
+		}
+	}
+}
+
 /*
 	Get a `treewalk.Node` that starts at the root of the bucket.
 	The walk will be in deterministic, sorted order (and thus is appropriate


### PR DESCRIPTION
If a tar file contains an implicit directory before an explicitly defined directory, rio will create the implicit directory then error when attempting to create the explicit one. To deal with this, we need to update directories instead of adding them with an implicit directory already exists.

This PR implements a sorted map for the MemoryBucket type to allow for efficient updates. It also modifies the strategy for tar unpacking to update duplicated dirs when needed. Finally, we allow all dirs (not just the root) to be updated, which will modify attrs.